### PR TITLE
Make services optional

### DIFF
--- a/microservice-base/templates/service.yaml
+++ b/microservice-base/templates/service.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.apps }}
+{{- if .service }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,4 +33,5 @@ spec:
       nodePort: {{ .service.nodePort }}
       {{- end }}
 ---
+{{- end }}
 {{- end }}


### PR DESCRIPTION
At the moment, all deployments using this chart have a service defined, e.g.:
```
$ k get service | grep bancho
bancho-service-api-production                            ClusterIP   10.98.80.7       <none>        80/TCP              4d19h
bancho-service-consume-pubsub-events-daemon-production   ClusterIP   10.105.143.20    <none>        80/TCP              4d19h
bancho-service-inactivity-timeout-cronjob-production     ClusterIP   10.102.127.238   <none>        80/TCP              4d19h
bancho-service-spam-protection-cronjob-production        ClusterIP   10.103.206.247   <none>        80/TCP              4d19h
```
This includes non-network application like cronjobs and daemons, which is unnecessary.