### PR TITLE
Remove Istio sidecar injection label

### DIFF
--- a/microservice-base/templates/deployment.yaml
+++ b/microservice-base/templates/deployment.yaml
@@ -20,9 +20,6 @@ spec:
       labels:
         app: {{ .name }}-{{ .environment }}
         group: {{ .group }}
-        {{- if not .service }}
-        sidecar.istio.io/inject: "false"
-        {{- end }}
       annotations:
           rollme: {{ randAlphaNum 5 | quote }}
     spec:


### PR DESCRIPTION
## Summary
- Remove conditional Istio sidecar injection label from deployment templates
- Istio has been uninstalled from the cluster

## Test plan
- [ ] Verify Helm deployments work correctly without the Istio label

🤖 Generated with [Claude Code](https://claude.com/claude-code)